### PR TITLE
ci: cap artifact retention at 7 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           name: dist
           path: public
+          retention-days: 7


### PR DESCRIPTION
## Summary

- **Problem:** `upload-artifact` had no `retention-days` set, defaulting to GitHub's 90-day retention
- **Fix:** add `retention-days: 7` to the dist artifact upload step
- **Impact:** stops unbounded storage accumulation (~25 MB per Dependabot merge, compounding over 90 days)

## Rationale

The dist artifact is a webpack-built static bundle uploaded on every CI run (every push/PR, including every Dependabot merge). With no retention limit, GitHub keeps these for 90 days by default. Since there are frequent Dependabot bumps, artifacts were accumulating rapidly with no automatic cleanup.

7 days is enough time to grab a recent build manually if needed for debugging. Production deploys go directly to S3, so artifacts are not part of the release flow and don't need long retention.